### PR TITLE
Add workaround for bug in winston-papertrail

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,13 @@ var engines = {
 
     spec = _.extend({ program: process.title }, spec);
 
-    return new winstonPapertrail(spec);
+    var transport = new winstonPapertrail(spec);
+
+    // Workaround due to bug in winston-papertrail
+    // https://github.com/kenperkins/winston-papertrail/issues/40
+    transport.exceptionsLevel = 'error';
+
+    return transport;
   }
 };
 


### PR DESCRIPTION
When using `handleExceptions` to effect logging of uncaught exceptions, nothing sensible would be logged. This fixes that, so a proper log message is produced.