### PR TITLE
Handle exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,23 @@ configurations, for example:
 console
 -------
 
-To output logs to the console, use this configuration:
+To output logs to the console, this configuration is sufficient:
 
     {
       "transport": "console"
     }
 
-Console output has no configuration options.
+Additional options are:
+
+ * `level`: The minimum level of log messages to output to this logger, for
+   example `"info"`. Keep this unset to allow all messages that are accepted
+   by the logger object
+ * `handleExceptions`: Set to `true` to intercept unhandled exceptions and
+   output them to this log target
+ * `exceptionsLevel`: The log level at which to log exceptions. Defaults to
+   `"error"`
+ * `humanReadableUnhandledException`: Format exception log output in a more
+   readable fashion
 
 syslog
 ------

--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ winstonSyslog.prototype.log = function (level, msg, meta, callback) {
 };
 
 var engines = {
-  "console": function () { return new TaggedConsoleTarget(); },
+  "console": function (spec) {
+    return new TaggedConsoleTarget(spec);
+  },
 
   "syslog": function (spec) {
     var options = {};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Creates an instance of TaggedLogger",
   "main": "index.js",
   "dependencies": {
-    "tagged-console-target": "^1.0.4",
+    "tagged-console-target": "^1.1.0",
     "tagged-logger": "^1.0.0",
     "underscore": "^1.8.2",
     "winston": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Creates an instance of TaggedLogger",
   "main": "index.js",
   "dependencies": {
-    "tagged-console-target": "~1.0.4",
-    "tagged-logger": "~1.0.0",
+    "tagged-console-target": "^1.0.4",
+    "tagged-logger": "^1.0.0",
     "underscore": "^1.8.2",
     "winston": "^0.9.0",
     "winston-papertrail": "^1.0.1",


### PR DESCRIPTION
Bump tagged-console-target dependency. This adds support for `handleExceptions` to the console target.